### PR TITLE
No indent before Idenfitier, initialize parent on ErrorController

### DIFF
--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -34,6 +34,8 @@ class ErrorController extends AppController
      */
     public function initialize(): void
     {
+		parent::initialize();
+
         $this->loadComponent('RequestHandler');
     }
 

--- a/src/View/Helper/NotificationHelper.php
+++ b/src/View/Helper/NotificationHelper.php
@@ -48,7 +48,7 @@ class NotificationHelper extends Helper
 					<p><strong>${title}</strong><br />${content}</p>
 				</div>
 			</div>
-			HTML;
+HTML;
 		}
 
 		return $notification;


### PR DESCRIPTION
### [Identifier must not be indented](https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc):

It was throwing this error:

```
[ParseError] syntax error, unexpected end of file in ...\cake-base-5\src\View\Helper\NotificationHelper.php on line 56
```

### parent:initialize();
When there's an error (like the above one) and ErrorController loads, it throws an error because it has it own initialize method but it's not itinitializing it's parent:

```
Undefined property: ErrorController::$Authentication in ...\cake-base-5\src\Controller\AppController.php on line 97 [CORE\src\Controller\Controller.php, line 314]
```
